### PR TITLE
Fix error caused by a blockquote inside a p tag on About page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -7,10 +7,8 @@ const About = () => (
     <p className="title" >About</p>
     <div className="content">
       <div className="leftcolumn">
-        <div className="paragraph">
-          The Code for America mission is, in part, to
+          <p>The Code for America mission is, in part, to</p>
           <blockquote>build open source technology and organize a network of people dedicated to making government services simple, effective, and easy to use.</blockquote>
-        </div>
         <p>
           As a Code for America Brigade, CfG extends this mission to the government and citizens of Greensboro. Our mission is to improve access to city data, to assist in creating and bettering city websites—and generally making the relationship between the city and the citizens better through technology.
         </p>

--- a/pages/about.js
+++ b/pages/about.js
@@ -7,11 +7,10 @@ const About = () => (
     <p className="title" >About</p>
     <div className="content">
       <div className="leftcolumn">
-        <p>
+        <div className="paragraph">
           The Code for America mission is, in part, to
           <blockquote>build open source technology and organize a network of people dedicated to making government services simple, effective, and easy to use.</blockquote>
-        </p>
-
+        </div>
         <p>
           As a Code for America Brigade, CfG extends this mission to the government and citizens of Greensboro. Our mission is to improve access to city data, to assist in creating and bettering city websites—and generally making the relationship between the city and the citizens better through technology.
         </p>

--- a/styles.scss
+++ b/styles.scss
@@ -43,6 +43,13 @@ $footer-background-color: $footer-background;
   }
 }
 
+// About page
+
+.content > .leftcolumn > .paragraph {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
 // footer at bottom of page or content
 html,
 body {

--- a/styles.scss
+++ b/styles.scss
@@ -43,13 +43,6 @@ $footer-background-color: $footer-background;
   }
 }
 
-// About page
-
-.content > .leftcolumn > .paragraph {
-  margin-top: 1em;
-  margin-bottom: 1em;
-}
-
 // footer at bottom of page or content
 html,
 body {


### PR DESCRIPTION
## Description
There was an error on the About page caused by a blockquote tag inside a p tag, so I have replaced the p tag with a div with the same style as a paragraph.

## Related Issue

#23 

## Motivation and Context

Fix the error on the about page.

## How Has This Been Tested?

I just tested on the browser.

## Screenshots (if appropriate):

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
